### PR TITLE
New interface: cloud.Node

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 285935ed2b82fbb0081751c5004fa7ea6c85c53577738a64e3df2095a6bc22b6
-updated: 2017-03-31T16:32:54.511223764+01:00
+hash: 660efb724b001c3c54377ebe13ea375d024bfa3417bcd4cfd5dbeb934d8f4099
+updated: 2017-04-13T14:01:10.543125532+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 38dd25dcbd6cec1983fe05abc880d6a3aa49a962
+  version: 7be45195c3af1b54a609812f90c05a7e492e2491
   subpackages:
   - aws
   - aws/awserr
@@ -37,9 +37,9 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/spf13/cobra
-  version: fcd0c5a1df88f5d6784cb4feead962c3f3d0b66c
+  version: 5deb57bbca49eb370538fc295ba4b2988f9f5e09
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: e453343e6260b4a3a89f1f0e10a2fbb07f8d9750
 - name: github.com/spf13/viper
-  version: 7538d73b4eb9511d85a9f1dfef202eeb8ac260f4
+  version: 5d46e70da8c0b6f812e0b170b7a985753b5c63cb
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,7 @@ package: github.com/UKHomeOffice/keto
 import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
+- package: github.com/aws/aws-sdk-go
+  version: v1.8.12
+  subpackages:
+  - aws/ec2metadata

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -30,6 +30,9 @@ type Interface interface {
 	// NodePooler returns a node pools interface. Also returns true if the
 	// interface is supported, false otherwise.
 	NodePooler() (NodePooler, bool)
+	// Node returns a node interface. Also returns true if the interface is
+	// supported, false otherwise.
+	Node() (Node, bool)
 }
 
 // Clusters is an abstract interface for clusters.
@@ -59,9 +62,6 @@ type NodePooler interface {
 	GetMasterPools(clusterName, name string) ([]*model.MasterPool, error)
 	// GetComputePools returns a list of compute pools in the cloud.
 	GetComputePools(clusterName, name string) ([]*model.ComputePool, error)
-	// GetKubeAPIURL returns a full URL to Kubernetes API. This usually points
-	// at a load balancer.
-	GetKubeAPIURL(clusterName string) (string, error)
 	// DescribeNodePool describes a given node pool.
 	// TODO
 	DescribeNodePool() error
@@ -71,4 +71,13 @@ type NodePooler interface {
 	// DeleteNodePool deletes a node pool.
 	// TODO
 	DeleteNodePool(clusterName, name string) error
+}
+
+// Node is an abstract interface for interacting to a cloud provider when
+// running on a cloud instance.
+type Node interface {
+	// GetKubeAPIURL returns a full URL to Kubernetes API.
+	GetKubeAPIURL() (string, error)
+	// GetKubeVersion returns a kubernetes version string.
+	GetKubeVersion() (string, error)
 }

--- a/pkg/cloudprovider/providers/aws/node.go
+++ b/pkg/cloudprovider/providers/aws/node.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"github.com/UKHomeOffice/keto/pkg/cloudprovider"
+)
+
+// Node returns an implementation of Node interface for AWS Cloud.
+func (c *Cloud) Node() (cloudprovider.Node, bool) {
+	return c, true
+}
+
+// GetKubeAPIURL returns a full URL to Kubernetes API.
+func (c *Cloud) GetKubeAPIURL() (string, error) {
+	instanceID, err := c.getInstanceID()
+	if err != nil {
+		return "", err
+	}
+	return c.getResourceTagValue(instanceID, kubeAPIURLTagKey)
+}
+
+// GetKubeVersion returns a kubernetes version string.
+func (c *Cloud) GetKubeVersion() (string, error) {
+	instanceID, err := c.getInstanceID()
+	if err != nil {
+		return "", err
+	}
+	return c.getResourceTagValue(instanceID, kubeVersionTagKey)
+}
+
+// getInstanceID returns an instance ID from EC2 metadata service.
+func (c Cloud) getInstanceID() (string, error) {
+	return c.ec2Metadata.GetMetadata("instance-id")
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -96,7 +96,7 @@ func (c *Controller) CreateMasterPool(p model.MasterPool) error {
 		return err
 	}
 
-	cloudConfig, err := c.UserData.RenderMasterCloudConfig(p.ClusterName, p.KubeVersion, ips)
+	cloudConfig, err := c.UserData.RenderMasterCloudConfig(c.Cloud.ProviderName(), p.ClusterName, p.KubeVersion, ips)
 	if err != nil {
 		return err
 	}

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -32,6 +32,7 @@ func New() *UserData {
 
 // RenderMasterCloudConfig renders a master cloud-config.
 func (u UserData) RenderMasterCloudConfig(
+	cloudProviderName string,
 	clusterName string,
 	kubeVersion string,
 	masterPersistentNodeIDIP map[string]string,
@@ -481,10 +482,12 @@ write_files:
 `
 
 	data := struct {
+		CloudProviderName        string
 		ClusterName              string
 		KubeVersion              string
 		MasterPersistentNodeIDIP map[string]string
 	}{
+		CloudProviderName:        cloudProviderName,
 		ClusterName:              clusterName,
 		KubeVersion:              kubeVersion,
 		MasterPersistentNodeIDIP: masterPersistentNodeIDIP,


### PR DESCRIPTION
Add cloud.Node interface
    
This interface is to be used for when keto cloudprovider is used as a library and to run on a machine itself. It allows for discovering kube api url, kube version, etc.
