### PR TITLE
Add masterhosts forcount

### DIFF
--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -185,6 +185,7 @@ coreos:
         -v /data/ca/kube:/data/ca/kube \
         -v /run/kubeapiserver:/run/kubeapiserver \
         -v /etc/kubernetes/:/etc/kubernetes/ \
+        -e ETCD_INITIAL_CLUSTER \
         -e ETCD_ADVERTISE_CLIENT_URLS \
         -e ETCD_CA_FILE \
         quay.io/ukhomeofficedigital/kmm \


### PR DESCRIPTION
Pass the ETCD_INITIAL_CLUSTER env to kmm to derive the master count for api servers.

See https://github.com/UKHomeOffice/keto-k8/pull/11 (also need review).