### PR TITLE
Working kubelet

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// DefaultKubeVersion specifies a default kubernetes version.
-	DefaultKubeVersion = "v1.6.1"
+	DefaultKubeVersion = "v1.6.2"
 	// DefaultComputePoolSize specifies a default number of machines in a single compute pool.
 	DefaultComputePoolSize = 1
 	// DefaultDiskSizeInGigabytes specifies a default node disk size in gigabytes.
@@ -10,7 +10,7 @@ const (
 	// DefaultCoreOSVersion specifies a default CoreOS version.
 	// TODO only works for AWS cloud for now. Need to figure out some sort of
 	// validation and CoreOS version to cloud image name mapping.
-	DefaultCoreOSVersion = "CoreOS-beta-1325.2.0-hvm"
+	DefaultCoreOSVersion = "CoreOS-stable-1353.6.0-hvm"
 )
 
 var (

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -213,6 +213,7 @@ coreos:
       Environment="RKT_OPTS=\
         --uuid-file-save=/var/run/kubelet-pod.uuid \
         --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+        --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log \
         --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
       EnvironmentFile=/etc/environment
       ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
@@ -230,20 +231,14 @@ coreos:
         --cni-conf-dir=/etc/cni/net.d \
         --kubeconfig=/etc/kubernetes/kubelet.conf \
         --lock-file=/var/run/lock/kubelet.lock \
-        --minimum-container-ttl-duration=3m0s \
         --network-plugin=cni \
         --hostname-override="${COREOS_PRIVATE_IPV4}" \
-        --node-labels=master=true \
         --pod-manifest-path=/etc/kubernetes/manifests \
-        --api-servers=https://${COREOS_PRIVATE_IPV4}:6443 \
         --require-kubeconfig=true \
         --image-gc-high-threshold=60 \
         --image-gc-low-threshold=40 \
-        --logtostderr=true \
-        --maximum-dead-containers-per-container=1 \
-        --maximum-dead-containers=10 \
-        --register-schedulable=false \
-        --system-reserved=cpu=50m,memory=100Mi
+        --system-reserved=cpu=50m,memory=100Mi \
+        --logtostderr=true
 
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
       Restart=always


### PR DESCRIPTION
This is required for the kubelet to schedule the DNS pods see https://github.com/UKHomeOffice/keto-k8/issues/14.

Also tidies up some kubelet options. Will be moving kubelet to keto-k8 after implementing https://github.com/UKHomeOffice/keto-k8/issues/10.