### PR TITLE
Update node interface to allow keto-tokens to use appropriate aws tags

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -85,4 +85,6 @@ type Node interface {
 	GetKubeVersion() (string, error)
 	// GetAssets gets assets onto a filesystem.
 	GetAssets() (model.Assets, error)
+	// GetClusterName gets the "name" of the cluster
+	GetClusterName() (string, error)
 }

--- a/pkg/cloudprovider/providers/aws/node.go
+++ b/pkg/cloudprovider/providers/aws/node.go
@@ -23,6 +23,15 @@ func (c *Cloud) GetKubeAPIURL() (string, error) {
 	return c.getResourceTagValue(metadata.InstanceID, kubeAPIURLTagKey)
 }
 
+// GetClusterName returns the cluster-name value.
+func (c *Cloud) GetClusterName() (string, error) {
+	metadata, err := getInstanceMetadata()
+	if err != nil {
+		return "", err
+	}
+	return c.getResourceTagValue(metadata.InstanceID, clusterNameTagKey)
+}
+
 // GetKubeVersion returns a kubernetes version string.
 func (c *Cloud) GetKubeVersion() (string, error) {
 	metadata, err := getInstanceMetadata()


### PR DESCRIPTION
Need this in first for running keto-tokens from keto-k8 (it consumes the value and passes to keto-tokens).