### PR TITLE
Kube API networks

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -426,7 +426,7 @@ func (c *Cloud) CreateMasterPool(p model.MasterPool) error {
 
 // createLoadBalancer ensures a load balancer is created.
 func (c *Cloud) createLoadBalancer(p model.MasterPool) error {
-	subnets, err := c.describeSubnets(p.Networks)
+	subnets, err := c.describeSubnets(p.KubeAPINetworks)
 	if err != nil {
 		return err
 	}
@@ -434,8 +434,8 @@ func (c *Cloud) createLoadBalancer(p model.MasterPool) error {
 	if err != nil {
 		return err
 	}
-
 	infraStackName := makeClusterInfraStackName(p.ClusterName)
+
 	return c.createELBStack(p, vpcID, infraStackName)
 }
 

--- a/pkg/cloudprovider/providers/aws/cloudformation_templates.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation_templates.go
@@ -271,7 +271,7 @@ Outputs:
 		ClusterInfraStackName string
 	}{
 		ClusterName: p.ClusterName,
-		Networks:    p.Networks,
+		Networks:    p.KubeAPINetworks,
 		VpcID:       vpcID,
 		ClusterInfraStackName: clusterInfraStackName,
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,9 +15,15 @@ const (
 	// TODO only works for AWS cloud for now. Need to figure out some sort of
 	// validation and CoreOS version to cloud image name mapping.
 	DefaultCoreOSVersion = "CoreOS-stable-1353.6.0-hvm"
+	// DefaultClusterName is the cluster name
+	DefaultClusterName = "cluster"
+	// DefaultMasterName is the name of the masterpool prefix
+	DefaultMasterName = "masterpool"
+	// DefaultComputeName is the name of the masterpool prefix
+	DefaultComputeName = "computepool"
 )
 
 var (
 	// ValidResourceTypes contains a list of currently supported resource types.
-	ValidResourceTypes = []string{"cluster", "masterpool", "computepool"}
+	ValidResourceTypes = []string{DefaultClusterName, DefaultMasterName, DefaultComputeName}
 )

--- a/pkg/keto/cmd/delete.go
+++ b/pkg/keto/cmd/delete.go
@@ -54,7 +54,7 @@ func validateDeleteFlags(c *cobra.Command, args []string) error {
 	}
 
 	// Check if mandatory flags are set when deleting a computepool or a masterpool.
-	if args[0] == "computepool" || args[0] == "masterpool" {
+	if args[0] == constants.DefaultComputeName || args[0] == constants.DefaultMasterName {
 		if !c.Flags().Changed("cluster") {
 			return fmt.Errorf("cluster name must be set")
 		}
@@ -80,9 +80,9 @@ func runDelete(c *cobra.Command, args []string) error {
 	switch resType {
 	case "cluster":
 		return cli.ctrl.DeleteCluster(resName)
-	case "masterpool":
+	case constants.DefaultMasterName:
 		return cli.ctrl.DeleteMasterPool(clusterName)
-	case "computepool":
+	case constants.DefaultComputeName:
 		return cli.ctrl.DeleteComputePool(clusterName, resName)
 	}
 

--- a/pkg/keto/cmd/get.go
+++ b/pkg/keto/cmd/get.go
@@ -74,11 +74,11 @@ func runGet(c *cobra.Command, args []string) error {
 	}
 
 	switch res {
-	case "cluster":
+	case constants.DefaultClusterName:
 		return listClusters(cli, resName)
-	case "masterpool":
+	case constants.DefaultMasterName:
 		return listMasterPools(cli, clusterName, resName)
-	case "computepool":
+	case constants.DefaultComputeName:
 		return listComputePools(cli, clusterName, resName)
 	}
 	return nil

--- a/pkg/keto/cmd/keto.go
+++ b/pkg/keto/cmd/keto.go
@@ -104,6 +104,11 @@ func addNetworksFlag(c *cobra.Command) {
 	c.Flags().StringSlice("networks", []string{}, "Cloud specific list of comma separated networks")
 }
 
+// addAPINetworksFlag add the network flags for kubeapi
+func addAPINetworksFlag(c *cobra.Command) {
+	c.Flags().StringSlice("api-networks", []string{}, "List of networks the kube api is attached (default to master subnets)")
+}
+
 // addCoreOSVersionFlag adds an OS flag
 func addCoreOSVersionFlag(c *cobra.Command) {
 	c.Flags().String("coreos-version", "", fmt.Sprintf("Operating system (default %q)", constants.DefaultCoreOSVersion))

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -38,7 +38,8 @@ type Labels map[string]string
 
 // MasterPool is a representation of a master control plane node pool.
 type MasterPool struct {
-	KubeAPIURL string
+	KubeAPIURL      string
+	KubeAPINetworks []string
 	NodePool
 }
 


### PR DESCRIPTION
- adding the --api-networks options to permit change the kubeapi networks
- cleaned up the loading of the certificates
- moved the pools names into constants to make it easier to reference
- related to https://github.com/UKHomeOffice/keto/issues/54