### PR TITLE
Add logging

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package aws
 
 import (
+	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,6 +37,10 @@ import (
 
 	"github.com/stretchr/testify/mock"
 )
+
+func makeLogger() *log.Logger {
+	return log.New(os.Stderr, "", log.LstdFlags)
+}
 
 func TestGetVPCIDFromSubnetList(t *testing.T) {
 	testCases := []struct {
@@ -82,8 +88,9 @@ func TestCreateClusterInfra(t *testing.T) {
 	mockCF := &mocks.CloudFormationAPI{}
 	mockEC2 := &mocks.EC2API{}
 	c := &Cloud{
-		cf:  mockCF,
-		ec2: mockEC2,
+		Logger: makeLogger(),
+		cf:     mockCF,
+		ec2:    mockEC2,
 	}
 
 	clusterName := "foo"
@@ -137,7 +144,8 @@ func TestCreateClusterInfra(t *testing.T) {
 func TestGetClusters(t *testing.T) {
 	mockCF := &mocks.CloudFormationAPI{}
 	c := &Cloud{
-		cf: mockCF,
+		Logger: makeLogger(),
+		cf:     mockCF,
 	}
 
 	stacks := []*cloudformation.Stack{
@@ -197,7 +205,8 @@ func TestGetClusters(t *testing.T) {
 func TestDeleteComputePool(t *testing.T) {
 	mockCF := &mocks.CloudFormationAPI{}
 	c := &Cloud{
-		cf: mockCF,
+		Logger: makeLogger(),
+		cf:     mockCF,
 	}
 
 	stacks := []*cloudformation.Stack{
@@ -247,9 +256,10 @@ func TestCreateMasterPool(t *testing.T) {
 	mockEC2 := &mocks.EC2API{}
 	mockELB := &mocks.ELBAPI{}
 	c := &Cloud{
-		cf:  mockCF,
-		ec2: mockEC2,
-		elb: mockELB,
+		Logger: makeLogger(),
+		cf:     mockCF,
+		ec2:    mockEC2,
+		elb:    mockELB,
 	}
 
 	clusterName := "foo"

--- a/pkg/cloudprovider/providers/aws/cloudformation.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation.go
@@ -240,7 +240,6 @@ func getNodesDistributionAcrossNetworks(subnets []*ec2.Subnet) []nodesNetwork {
 		n := dist[0]
 		n.NodeID = total
 		dist = append(dist, n)
-		total++
 	}
 	return dist
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"log"
+	"os"
 	"testing"
 
 	cloudProviderMocks "github.com/UKHomeOffice/keto/pkg/cloudprovider/mocks"
@@ -133,6 +135,10 @@ func makeTestMock() (*testMock, *Controller) {
 	m.Provider.On("Clusters").Return(m.Clusters, true)
 	m.Provider.On("NodePooler").Return(m.NodePooler, true)
 
-	ctrl := New(Config{Cloud: m.Provider, UserData: m.UserData})
+	ctrl := New(Config{
+		Logger:   log.New(os.Stderr, "", log.LstdFlags),
+		Cloud:    m.Provider,
+		UserData: m.UserData,
+	})
 	return m, ctrl
 }

--- a/pkg/keto/cmd/delete.go
+++ b/pkg/keto/cmd/delete.go
@@ -51,7 +51,13 @@ func deleteClusterCmdFunc(c *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return cli.ctrl.DeleteCluster(name)
+
+	cli.logger.Printf("Deleting cluster %q", name)
+	if err := cli.ctrl.DeleteCluster(name); err != nil {
+		return err
+	}
+	cli.logger.Printf("Cluster %q successfully deleted", name)
+	return nil
 }
 
 var deleteMasterPoolCmd = &cobra.Command{
@@ -77,7 +83,12 @@ func deleteMasterPoolCmdFunc(c *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return cli.ctrl.DeleteMasterPool(clusterName)
+	cli.logger.Printf("Deleting masterpool of cluster %q", clusterName)
+	if err := cli.ctrl.DeleteMasterPool(clusterName); err != nil {
+		return err
+	}
+	cli.logger.Printf("Masterpool successfully deleted")
+	return nil
 }
 
 var deleteComputePoolCmd = &cobra.Command{
@@ -108,7 +119,12 @@ func deleteComputePoolCmdFunc(c *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return cli.ctrl.DeleteComputePool(clusterName, name)
+	cli.logger.Printf("Deleting computepool %q of cluster %q", name, clusterName)
+	if err := cli.ctrl.DeleteComputePool(clusterName, name); err != nil {
+		return err
+	}
+	cli.logger.Printf("Computepool %q successfully deleted", name)
+	return nil
 }
 
 func validateDeleteFlags(c *cobra.Command, args []string) error {

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -30,14 +30,21 @@ type UserDater interface {
 }
 
 // UserData defines a user data struct.
-type UserData struct{}
+type UserData struct {
+	Logger logger
+}
+
+// logger is a generic interface that is used for passing in a logger.
+type logger interface {
+	Printf(string, ...interface{})
+}
 
 // Compile-time check whether UserData type value implements UserDater interface.
 var _ UserDater = (*UserData)(nil)
 
 // New returns a new UserData struct
-func New() *UserData {
-	return &UserData{}
+func New(logger logger) *UserData {
+	return &UserData{Logger: logger}
 }
 
 // RenderMasterCloudConfig renders a master cloud-config.
@@ -334,6 +341,8 @@ write_files:
 		return b.Bytes(), err
 	}
 
+	u.Logger.Printf("cloud-config for masterpool: %s", b.String())
+
 	return b.Bytes(), nil
 }
 
@@ -491,6 +500,8 @@ write_files:
 	if err := t.Execute(&b, data); err != nil {
 		return b.Bytes(), err
 	}
+
+	u.Logger.Printf("cloud-config for computepool: %s", b.String())
 
 	return b.Bytes(), nil
 }

--- a/pkg/userdata/userdata_test.go
+++ b/pkg/userdata/userdata_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package userdata
 
 import (
+	"log"
+	"os"
 	"testing"
 
 	"github.com/UKHomeOffice/keto/testutil"
@@ -27,7 +29,7 @@ import (
 const clusterName = "foo"
 
 func TestRenderMasterCloudConfig(t *testing.T) {
-	u := New()
+	u := New(log.New(os.Stderr, "", log.LstdFlags))
 	s, err := u.RenderMasterCloudConfig("aws", clusterName, "v1.7.0", map[string]string{"0": "10.0.0.1"})
 	if err != nil {
 		t.Error(err)
@@ -36,7 +38,7 @@ func TestRenderMasterCloudConfig(t *testing.T) {
 }
 
 func TestRenderComputeCloudConfig(t *testing.T) {
-	u := New()
+	u := New(log.New(os.Stderr, "", log.LstdFlags))
 	s, err := u.RenderComputeCloudConfig("aws", clusterName, "v1.7.0")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Overall, the principle is that a logger can be passed to different code paths: cloudprovider, userdata, controller, etc. CLI is the bit that initializes cloudprovider, userdata and controller, so it decides where and when those components log. Currently, if debug flag is set (the default for now), the log output will go to stderr.

CLI ifself has two outputs:
- stderr for non-data output, like `Creating foo bar` messages
- stdout for keto data output, like printing a list of resources