### PR TITLE
Implement DNS support

### DIFF
--- a/pkg/cloudprovider/providers/aws/cloudformation.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation.go
@@ -303,14 +303,14 @@ func makeMasterPoolStackName(clusterName, part string) string {
 	return fmt.Sprintf("keto-%s-%s-%s", clusterName, masterPoolStackType, part)
 }
 
-func (c *Cloud) createELBStack(p model.MasterPool, vpcID, infraStackName string) error {
-	templateBody, err := renderELBStackTemplate(p, vpcID, infraStackName)
+func (c *Cloud) createELBStack(cluster model.Cluster, vpcID, infraStackName string) error {
+	templateBody, err := renderELBStackTemplate(cluster, vpcID, infraStackName)
 	if err != nil {
 		return err
 	}
 	stack := &cloudformation.CreateStackInput{
-		StackName:    aws.String(makeELBStackName(p.ClusterName)),
-		Tags:         makeStackTags(p.ClusterName, elbStackType, "", "", "", "", "", "", 0, p.Internal),
+		StackName:    aws.String(makeELBStackName(cluster.Name)),
+		Tags:         makeStackTags(cluster.Name, elbStackType, "", "", "", "", "", "", 0, cluster.Internal),
 		TemplateBody: aws.String(templateBody),
 	}
 

--- a/pkg/cloudprovider/providers/aws/cloudformation_templates_test.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation_templates_test.go
@@ -54,14 +54,16 @@ func TestRenderClusterInfraStackTemplate(t *testing.T) {
 }
 
 func TestRenderELBStackTemplate(t *testing.T) {
-	pool := model.MasterPool{
-		NodePool: model.NodePool{
-			ResourceMeta: model.ResourceMeta{ClusterName: "foo"},
-			NodePoolSpec: model.NodePoolSpec{Networks: []string{"network0", "network1"}},
+	c := model.Cluster{
+		MasterPool: model.MasterPool{
+			NodePool: model.NodePool{
+				ResourceMeta: model.ResourceMeta{ClusterName: "foo"},
+				NodePoolSpec: model.NodePoolSpec{Networks: []string{"network0", "network1"}},
+			},
 		},
 	}
 
-	s, err := renderELBStackTemplate(pool, vpc, "infra-foo-stack")
+	s, err := renderELBStackTemplate(c, vpc, "infra-foo-stack")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/keto/cmd/create.go
+++ b/pkg/keto/cmd/create.go
@@ -113,6 +113,13 @@ func createClusterCmdFunc(c *cobra.Command, args []string) error {
 	}
 	cluster.Internal = internal
 
+	// DNSZone is not required.
+	dnsZone, err := c.Flags().GetString("dns-zone")
+	if err != nil {
+		return err
+	}
+	cluster.DNSZone = dnsZone
+
 	p, err := makeMasterPool("master", name, *c)
 	if err != nil {
 		return err

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -29,6 +29,7 @@ type Cluster struct {
 	ResourceMeta
 	MasterPool   MasterPool
 	ComputePools []ComputePool
+	DNSZone      string
 	Status
 }
 


### PR DESCRIPTION
Allows for passing in a `--dns-zone` parameter which is then used for adding a
DNS record to kube api ELB.

#### TODO
- [x] aws: check whether hosted zone exists before trying to create an ELB stack
