### PR TITLE
Bumped Kube version to v1.6.6 and k8 to v0.0.6

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,11 +2,11 @@ package constants
 
 const (
 	// DefaultKubeVersion specifies a default kubernetes version.
-	DefaultKubeVersion = "v1.6.4"
+	DefaultKubeVersion = "v1.6.6"
 	// DefaultNetworkProvider specifies what CNI provider to install
 	DefaultNetworkProvider = "canal"
 	// DefaultKetoK8Image specifies the image to use for keto-k8 container
-	DefaultKetoK8Image = "quay.io/ukhomeofficedigital/keto-k8:v0.0.5"
+	DefaultKetoK8Image = "quay.io/ukhomeofficedigital/keto-k8:v0.0.6"
 	// DefaultComputePoolSize specifies a default number of machines in a single compute pool.
 	DefaultComputePoolSize = 1
 	// DefaultDiskSizeInGigabytes specifies a default node disk size in gigabytes.


### PR DESCRIPTION
Related to: https://github.com/UKHomeOffice/keto-k8/pull/44#pullrequestreview-47655213

Will perform some additional validation on the build before moving forward, to confirm that there's no regression with the new image.