### PR TITLE
Refactor Node interface to incorporate labels

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -81,12 +81,8 @@ type NodePooler interface {
 // Node is an abstract interface for interacting with a cloud provider when
 // running on a cloud instance.
 type Node interface {
-	// GetKubeAPIURL returns a full URL to Kubernetes API.
-	GetKubeAPIURL() (string, error)
-	// GetKubeVersion returns a kubernetes version string.
-	GetKubeVersion() (string, error)
-	// GetAssets gets assets onto a filesystem.
+	// GetAssets gets assets from a cloud.
 	GetAssets() (model.Assets, error)
-	// GetClusterName gets the "name" of the cluster
-	GetClusterName() (string, error)
+	// GetNodeData returns node data.
+	GetNodeData() (model.NodeData, error)
 }

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -773,6 +773,15 @@ func (c Cloud) getResourceTagValue(resourceID, key string) (string, error) {
 	return "", nil
 }
 
+func tagReserved(s string) bool {
+	for _, i := range stackTagsNotLabels {
+		if s == i {
+			return true
+		}
+	}
+	return false
+}
+
 // init registers AWS cloud with the cloudprovider.
 func init() {
 	// f knows how to initialize the cloud

--- a/pkg/cloudprovider/providers/aws/cloudformation.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation.go
@@ -92,18 +92,9 @@ func (c *Cloud) getStack(name string) (*cloudformation.Stack, error) {
 
 // getStackLabels returns a model.Labels of given a cloudformation stack
 func getStackLabels(s *cloudformation.Stack) model.Labels {
-	reservedTag := func(t *cloudformation.Tag) bool {
-		for _, i := range stackTagsNotLabels {
-			if *t.Key == i {
-				return true
-			}
-		}
-		return false
-	}
-
 	labels := model.Labels{}
 	for _, tag := range s.Tags {
-		if reservedTag(tag) {
+		if tagReserved(*tag.Key) {
 			continue
 		}
 		labels[*tag.Key] = *tag.Value

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -81,3 +81,11 @@ type Status struct {
 	Upgraded int64  `json:"upgraded,omitempty"`
 	State    string `json:"state,omitempty"`
 }
+
+// NodeData contains cloud Node related data.
+type NodeData struct {
+	KubeAPIURL  string
+	ClusterName string
+	KubeVersion string
+	Labels
+}


### PR DESCRIPTION
Changing cloud.Node interface to return a struct with node data instead
of separate calls for each node data item.