### PR TITLE
Fix filtering of aws tags

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -774,6 +774,9 @@ func (c Cloud) getResourceTagValue(resourceID, key string) (string, error) {
 }
 
 func tagReserved(s string) bool {
+	if strings.HasPrefix(s, "aws:") {
+		return true
+	}
 	for _, i := range stackTagsNotLabels {
 		if s == i {
 			return true


### PR DESCRIPTION
The kubelet will not start when tags have ":" in etc. This should fix the filter function.