### PR TITLE
labels: refactor

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/UKHomeOffice/keto/pkg/cloudprovider"
+	"github.com/UKHomeOffice/keto/pkg/constants"
 	"github.com/UKHomeOffice/keto/pkg/model"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,7 +56,8 @@ const (
 	// resources are managed by keto.
 	managedByKetoTagKey   = "managed-by-keto"
 	managedByKetoTagValue = "true"
-	clusterNameTagKey     = "cluster-name"
+	machineTypeTagKey     = "machine-type"
+	diskSizeTagKey        = "disk-size"
 
 	etcdCACertObjectName = "etcd_ca.crt"
 	etcdCAKeyObjectName  = "etcd_ca.key"
@@ -145,7 +147,7 @@ outer:
 	for _, s := range stacks {
 		c := &model.Cluster{}
 		for _, tag := range s.Tags {
-			if *tag.Key == clusterNameTagKey && *tag.Value != "" {
+			if *tag.Key == constants.ClusterNameLabelKey && *tag.Value != "" {
 				// if filtered by cluster name and the stack tag does not
 				// match it, skip over the stack
 				if name != "" && *tag.Value != name {
@@ -336,7 +338,7 @@ func (c Cloud) describePersistentENIs(clusterName string) ([]*ec2.NetworkInterfa
 				Values: []*string{aws.String(managedByKetoTagValue)},
 			},
 			{
-				Name:   aws.String("tag:" + clusterNameTagKey),
+				Name:   aws.String("tag:" + constants.ClusterNameLabelKey),
 				Values: []*string{aws.String(clusterName)},
 			},
 		},
@@ -513,13 +515,13 @@ outer:
 	for _, s := range stacks {
 		p := &model.MasterPool{}
 		for _, tag := range s.Tags {
-			if *tag.Key == clusterNameTagKey && *tag.Value != "" {
+			if *tag.Key == constants.ClusterNameLabelKey && *tag.Value != "" {
 				if clusterName != "" && *tag.Value != clusterName {
 					continue outer
 				}
 				p.ClusterName = *tag.Value
 			}
-			if *tag.Key == poolNameTagKey && *tag.Value != "" {
+			if *tag.Key == constants.PoolNameLabelKey && *tag.Value != "" {
 				if name != "" && *tag.Value != name {
 					continue outer
 				}
@@ -564,13 +566,13 @@ outer:
 	for _, s := range stacks {
 		p := &model.ComputePool{}
 		for _, tag := range s.Tags {
-			if *tag.Key == clusterNameTagKey && *tag.Value != "" {
+			if *tag.Key == constants.ClusterNameLabelKey && *tag.Value != "" {
 				if clusterName != "" && *tag.Value != clusterName {
 					continue outer
 				}
 				p.ClusterName = *tag.Value
 			}
-			if *tag.Key == poolNameTagKey && *tag.Value != "" {
+			if *tag.Key == constants.PoolNameLabelKey && *tag.Value != "" {
 				if name != "" && *tag.Value != name {
 					continue outer
 				}
@@ -619,7 +621,7 @@ func (c *Cloud) DeleteMasterPool(clusterName string) error {
 
 	for _, s := range stacks {
 		for _, tag := range s.Tags {
-			if *tag.Key == clusterNameTagKey && *tag.Value == clusterName {
+			if *tag.Key == constants.ClusterNameLabelKey && *tag.Value == clusterName {
 				if err := c.deleteStack(*s.StackId); err != nil {
 					return err
 				}
@@ -640,15 +642,15 @@ func (c *Cloud) DeleteComputePool(clusterName, name string) error {
 	matched := func(tags []*cloudformation.Tag) bool {
 		n := 0
 		for _, tag := range tags {
-			if *tag.Key == clusterNameTagKey && *tag.Value == clusterName {
+			if *tag.Key == constants.ClusterNameLabelKey && *tag.Value == clusterName {
 				n++
 			}
 			if name != "" {
-				if *tag.Key == poolNameTagKey && *tag.Value == name {
+				if *tag.Key == constants.PoolNameLabelKey && *tag.Value == name {
 					n++
 				}
 			}
-			if name == "" && *tag.Key == poolNameTagKey {
+			if name == "" && *tag.Key == constants.PoolNameLabelKey {
 				n++
 			}
 		}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/UKHomeOffice/keto/pkg/cloudprovider/providers/aws/mocks"
+	"github.com/UKHomeOffice/keto/pkg/constants"
 	"github.com/UKHomeOffice/keto/pkg/model"
 	"github.com/UKHomeOffice/keto/testutil"
 
@@ -166,7 +167,7 @@ func TestGetClusters(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(clusterNameTagKey),
+					Key:   aws.String(constants.ClusterNameLabelKey),
 					Value: aws.String("foo"),
 				},
 				{
@@ -187,7 +188,7 @@ func TestGetClusters(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(clusterNameTagKey),
+					Key:   aws.String(constants.ClusterNameLabelKey),
 					Value: aws.String("bar"),
 				},
 				{
@@ -236,11 +237,11 @@ func TestDeleteComputePool(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(clusterNameTagKey),
+					Key:   aws.String(constants.ClusterNameLabelKey),
 					Value: aws.String("foo"),
 				},
 				{
-					Key:   aws.String(poolNameTagKey),
+					Key:   aws.String(constants.PoolNameLabelKey),
 					Value: aws.String("compute"),
 				},
 				{
@@ -289,7 +290,7 @@ func TestCreateMasterPool(t *testing.T) {
 				Values: []*string{aws.String(managedByKetoTagValue)},
 			},
 			{
-				Name:   aws.String("tag:" + clusterNameTagKey),
+				Name:   aws.String("tag:" + constants.ClusterNameLabelKey),
 				Values: []*string{aws.String(clusterName)},
 			},
 		},

--- a/pkg/cloudprovider/providers/aws/node.go
+++ b/pkg/cloudprovider/providers/aws/node.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/UKHomeOffice/keto/pkg/cloudprovider"
+	"github.com/UKHomeOffice/keto/pkg/constants"
 	"github.com/UKHomeOffice/keto/pkg/model"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -36,7 +37,7 @@ func (c Cloud) GetNodeData() (model.NodeData, error) {
 			data.KubeAPIURL = *t.Value
 		}
 
-		if *t.Key == clusterNameTagKey {
+		if *t.Key == constants.ClusterNameLabelKey {
 			data.ClusterName = *t.Value
 		}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,4 +15,9 @@ const (
 	// TODO only works for AWS cloud for now. Need to figure out some sort of
 	// validation and CoreOS version to cloud image name mapping.
 	DefaultCoreOSVersion = "CoreOS-stable-1353.8.0-hvm"
+
+	// ClusterNameLabelKey label key name for cluster name label.
+	ClusterNameLabelKey = "cluster-name"
+	// PoolNameLabelKey label key name for pool name label.
+	PoolNameLabelKey = "pool-name"
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -94,6 +94,13 @@ func (c *Controller) CreateCluster(cluster model.Cluster, assets model.Assets) e
 		c.Logger.Printf("cluster is internal, node pools will also be internal")
 	}
 
+	// Initialize Labels map in case it hasn't been.
+	if cluster.Labels == nil {
+		cluster.Labels = model.Labels{}
+	}
+	// Set default cluster labels.
+	cluster.Labels[constants.ClusterNameLabelKey] = cluster.Name
+
 	c.Logger.Printf("creating cluster %q infrastructure", cluster.Name)
 	if err := cl.CreateClusterInfra(cluster); err != nil {
 		return err
@@ -183,6 +190,15 @@ func (c *Controller) CreateMasterPool(p model.MasterPool) error {
 	}
 	p.UserData = cloudConfig
 
+	// Cluster scope labels get applied to node pools by default.
+	if p.Labels == nil {
+		p.Labels = model.Labels{}
+	}
+	for k, v := range clusters[0].Labels {
+		p.Labels[k] = v
+	}
+	p.Labels[constants.PoolNameLabelKey] = p.Name
+
 	return pooler.CreateMasterPool(p)
 }
 
@@ -252,6 +268,15 @@ func (c *Controller) CreateComputePool(p model.ComputePool) error {
 		return err
 	}
 	p.UserData = cloudConfig
+
+	// Cluster scope labels get applied to node pools by default.
+	if p.Labels == nil {
+		p.Labels = model.Labels{}
+	}
+	for k, v := range clusters[0].Labels {
+		p.Labels[k] = v
+	}
+	p.Labels[constants.PoolNameLabelKey] = p.Name
 
 	return pooler.CreateComputePool(p)
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -24,6 +24,7 @@ import (
 	cloudProviderMocks "github.com/UKHomeOffice/keto/pkg/cloudprovider/mocks"
 	userdataMocks "github.com/UKHomeOffice/keto/pkg/userdata/mocks"
 
+	"github.com/UKHomeOffice/keto/pkg/constants"
 	"github.com/UKHomeOffice/keto/pkg/model"
 	"github.com/UKHomeOffice/keto/testutil"
 )
@@ -43,9 +44,15 @@ func TestCreateCluster(t *testing.T) {
 
 	persistentIPs := map[string]string{"node0": "1.1.1.1"}
 	cluster := model.Cluster{
-		ResourceMeta: model.ResourceMeta{Name: "foo"},
-		MasterPool:   model.MasterPool{NodePool: testutil.MakeNodePool("foo", "master")},
+		ResourceMeta: model.ResourceMeta{
+			Name: "foo",
+			Labels: model.Labels{
+				constants.ClusterNameLabelKey: "foo",
+			},
+		},
+		MasterPool: model.MasterPool{NodePool: testutil.MakeNodePool("foo", "master")},
 	}
+	cluster.MasterPool.Labels = cluster.Labels
 
 	m.Clusters.On("GetClusters", cluster.Name).Return([]*model.Cluster{}, nil).Once()
 	m.Clusters.On("CreateClusterInfra", cluster).Return(nil)

--- a/pkg/keto/cmd/create.go
+++ b/pkg/keto/cmd/create.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/UKHomeOffice/keto/pkg/model"
 
@@ -119,6 +120,12 @@ func createClusterCmdFunc(c *cobra.Command, args []string) error {
 		return err
 	}
 	cluster.DNSZone = dnsZone
+
+	labels, err := c.Flags().GetStringSlice("labels")
+	if err != nil {
+		return err
+	}
+	cluster.Labels = kvsTolabels(labels)
 
 	p, err := makeMasterPool("master", name, *c)
 	if err != nil {
@@ -282,6 +289,11 @@ func makeMasterPool(name, clusterName string, c cobra.Command) (model.MasterPool
 	if err != nil {
 		return p, err
 	}
+	labels, err := c.Flags().GetStringSlice("labels")
+	if err != nil {
+		return p, err
+	}
+	p.Labels = kvsTolabels(labels)
 
 	p.Name = name
 	p.ClusterName = clusterName
@@ -366,6 +378,11 @@ func makeComputePool(name, clusterName string, c cobra.Command) (model.ComputePo
 	if err != nil {
 		return p, err
 	}
+	labels, err := c.Flags().GetStringSlice("labels")
+	if err != nil {
+		return p, err
+	}
+	p.Labels = kvsTolabels(labels)
 
 	p.Name = name
 	p.ClusterName = clusterName
@@ -377,6 +394,17 @@ func makeComputePool(name, clusterName string, c cobra.Command) (model.ComputePo
 	p.MachineType = machineType
 	p.Size = size
 	return p, nil
+}
+
+func kvsTolabels(kvs []string) model.Labels {
+	labels := model.Labels{}
+	for _, kv := range kvs {
+		s := strings.SplitN(kv, "=", 2)
+		if len(s) == 2 {
+			labels[s[0]] = s[1]
+		}
+	}
+	return labels
 }
 
 func init() {


### PR DESCRIPTION
Move default global labels set up to controller. AWS implementation just
ensures that labels are set and retrieved in the cloudprovider specific
way, but it will no longer decide what should be the default labels.

This should allow for better labels abstraction.

Fixes #6