### PR TITLE
aws: refactor persistence to use stack outputs

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"github.com/UKHomeOffice/keto/pkg/cloudprovider/providers/aws/mocks"
-	"github.com/UKHomeOffice/keto/pkg/constants"
 	"github.com/UKHomeOffice/keto/pkg/model"
 	"github.com/UKHomeOffice/keto/testutil"
 
@@ -167,16 +166,22 @@ func TestGetClusters(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(constants.ClusterNameLabelKey),
+					Key:   aws.String(clusterNameTagKey),
 					Value: aws.String("foo"),
 				},
+			},
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(clusterInfraStackType),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(clusterInfraStackType),
 				},
 				{
-					Key:   aws.String(internalClusterTagKey),
-					Value: aws.String("true"),
+					OutputKey:   aws.String(internalClusterOutputKey),
+					OutputValue: aws.String("true"),
+				},
+				{
+					OutputKey:   aws.String(clusterNameOutputKey),
+					OutputValue: aws.String("foo"),
 				},
 			},
 		},
@@ -188,12 +193,18 @@ func TestGetClusters(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(constants.ClusterNameLabelKey),
+					Key:   aws.String(clusterNameTagKey),
 					Value: aws.String("bar"),
 				},
+			},
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(clusterInfraStackType),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(clusterInfraStackType),
+				},
+				{
+					OutputKey:   aws.String(clusterNameOutputKey),
+					OutputValue: aws.String("bar"),
 				},
 			},
 		},
@@ -237,16 +248,26 @@ func TestDeleteComputePool(t *testing.T) {
 					Value: aws.String(managedByKetoTagValue),
 				},
 				{
-					Key:   aws.String(constants.ClusterNameLabelKey),
+					Key:   aws.String(clusterNameTagKey),
 					Value: aws.String("foo"),
 				},
+			},
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(constants.PoolNameLabelKey),
-					Value: aws.String("compute"),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(computePoolStackType),
 				},
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(computePoolStackType),
+					OutputKey:   aws.String(internalClusterOutputKey),
+					OutputValue: aws.String("true"),
+				},
+				{
+					OutputKey:   aws.String(clusterNameOutputKey),
+					OutputValue: aws.String("foo"),
+				},
+				{
+					OutputKey:   aws.String(poolNameOutputKey),
+					OutputValue: aws.String("compute"),
 				},
 			},
 		},
@@ -290,7 +311,7 @@ func TestCreateMasterPool(t *testing.T) {
 				Values: []*string{aws.String(managedByKetoTagValue)},
 			},
 			{
-				Name:   aws.String("tag:" + constants.ClusterNameLabelKey),
+				Name:   aws.String("tag:" + clusterNameTagKey),
 				Values: []*string{aws.String(clusterName)},
 			},
 		},

--- a/pkg/cloudprovider/providers/aws/cloudformation_templates_test.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation_templates_test.go
@@ -45,8 +45,14 @@ func TestRenderClusterInfraStackTemplate(t *testing.T) {
 	}
 
 	networks := getNodesDistributionAcrossNetworks(subnets)
+	cluster := model.Cluster{
+		ResourceMeta: model.ResourceMeta{
+			Name:     "foo",
+			Internal: false,
+		},
+	}
 
-	s, err := renderClusterInfraStackTemplate("foo", vpc, networks)
+	s, err := renderClusterInfraStackTemplate(cluster, vpc, networks)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +69,7 @@ func TestRenderELBStackTemplate(t *testing.T) {
 		},
 	}
 
-	s, err := renderELBStackTemplate(c, vpc, "infra-foo-stack")
+	s, err := renderELBStackTemplate(c, vpc)
 	if err != nil {
 		t.Error(err)
 	}
@@ -84,7 +90,7 @@ func TestRenderMasterStackTemplate(t *testing.T) {
 		},
 	}
 
-	s, err := renderMasterStackTemplate(pool, "infra-foo-stack", ami, "myelb", "assets-bucket", nodesPerSubnet)
+	s, err := renderMasterStackTemplate(pool, ami, "myelb", "assets-bucket", nodesPerSubnet, "https://kube", "mystack")
 	if err != nil {
 		t.Error(err)
 	}
@@ -99,7 +105,7 @@ func TestRenderComputeStackTemplate(t *testing.T) {
 		},
 	}
 
-	s, err := renderComputeStackTemplate(pool, "infra-foo-stack", ami)
+	s, err := renderComputeStackTemplate(pool, "infra-foo-stack", ami, "mystack")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/cloudprovider/providers/aws/cloudformation_test.go
+++ b/pkg/cloudprovider/providers/aws/cloudformation_test.go
@@ -47,9 +47,11 @@ func TestGetStacksByType(t *testing.T) {
 					Key:   aws.String(managedByKetoTagKey),
 					Value: aws.String(managedByKetoTagValue),
 				},
+			},
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(masterPoolStackType),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(masterPoolStackType),
 				},
 			},
 		},
@@ -60,18 +62,20 @@ func TestGetStacksByType(t *testing.T) {
 					Key:   aws.String(managedByKetoTagKey),
 					Value: aws.String(managedByKetoTagValue),
 				},
+			},
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(computePoolStackType),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(computePoolStackType),
 				},
 			},
 		},
 		{
 			StackName: aws.String("compute-2"),
-			Tags: []*cloudformation.Tag{
+			Outputs: []*cloudformation.Output{
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(computePoolStackType),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(computePoolStackType),
 				},
 			},
 		},
@@ -98,23 +102,19 @@ func TestGetStacksByType(t *testing.T) {
 func TestGetStackLabels(t *testing.T) {
 	cases := []struct {
 		name  string
-		input []*cloudformation.Tag
+		input []*cloudformation.Output
 		want  model.Labels
 	}{
 		{
-			"label foo=bar, ignoring reserved labels",
-			[]*cloudformation.Tag{
+			"label foo=bar",
+			[]*cloudformation.Output{
 				{
-					Key:   aws.String(managedByKetoTagKey),
-					Value: aws.String(managedByKetoTagValue),
+					OutputKey:   aws.String(stackTypeOutputKey),
+					OutputValue: aws.String(computePoolStackType),
 				},
 				{
-					Key:   aws.String(stackTypeTagKey),
-					Value: aws.String(computePoolStackType),
-				},
-				{
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
+					OutputKey:   aws.String(labelsOutputKey),
+					OutputValue: aws.String("foo=bar"),
 				},
 			},
 			model.Labels{"foo": "bar"},
@@ -123,7 +123,7 @@ func TestGetStackLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := getStackLabels(&cloudformation.Stack{Tags: c.input})
+			got := getStackLabels(&cloudformation.Stack{Outputs: c.input})
 			if !reflect.DeepEqual(got, c.want) {
 				t.Errorf("got %#v; want %#v", got, c.want)
 			}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,7 +6,7 @@ const (
 	// DefaultNetworkProvider specifies what CNI provider to install
 	DefaultNetworkProvider = "canal"
 	// DefaultKetoK8Image specifies the image to use for keto-k8 container
-	DefaultKetoK8Image = "quay.io/ukhomeofficedigital/keto-k8:v0.1.0"
+	DefaultKetoK8Image = "quay.io/ukhomeofficedigital/keto-k8:v0.1.1-b1"
 	// DefaultComputePoolSize specifies a default number of machines in a single compute pool.
 	DefaultComputePoolSize = 1
 	// DefaultDiskSizeInGigabytes specifies a default node disk size in gigabytes.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -98,8 +98,6 @@ func (c *Controller) CreateCluster(cluster model.Cluster, assets model.Assets) e
 	if cluster.Labels == nil {
 		cluster.Labels = model.Labels{}
 	}
-	// Set default cluster labels.
-	cluster.Labels[constants.ClusterNameLabelKey] = cluster.Name
 
 	c.Logger.Printf("creating cluster %q infrastructure", cluster.Name)
 	if err := cl.CreateClusterInfra(cluster); err != nil {

--- a/pkg/keto/cmd/create.go
+++ b/pkg/keto/cmd/create.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
+	"github.com/UKHomeOffice/keto/pkg/keto/util"
 	"github.com/UKHomeOffice/keto/pkg/model"
 
 	"github.com/spf13/cobra"
@@ -125,7 +125,7 @@ func createClusterCmdFunc(c *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cluster.Labels = kvsTolabels(labels)
+	cluster.Labels = util.KVsToLabels(labels)
 
 	p, err := makeMasterPool("master", name, *c)
 	if err != nil {
@@ -293,7 +293,7 @@ func makeMasterPool(name, clusterName string, c cobra.Command) (model.MasterPool
 	if err != nil {
 		return p, err
 	}
-	p.Labels = kvsTolabels(labels)
+	p.Labels = util.KVsToLabels(labels)
 
 	p.Name = name
 	p.ClusterName = clusterName
@@ -382,7 +382,7 @@ func makeComputePool(name, clusterName string, c cobra.Command) (model.ComputePo
 	if err != nil {
 		return p, err
 	}
-	p.Labels = kvsTolabels(labels)
+	p.Labels = util.KVsToLabels(labels)
 
 	p.Name = name
 	p.ClusterName = clusterName
@@ -394,17 +394,6 @@ func makeComputePool(name, clusterName string, c cobra.Command) (model.ComputePo
 	p.MachineType = machineType
 	p.Size = size
 	return p, nil
-}
-
-func kvsTolabels(kvs []string) model.Labels {
-	labels := model.Labels{}
-	for _, kv := range kvs {
-		s := strings.SplitN(kv, "=", 2)
-		if len(s) == 2 {
-			labels[s[0]] = s[1]
-		}
-	}
-	return labels
 }
 
 func init() {

--- a/pkg/keto/resource_printer.go
+++ b/pkg/keto/resource_printer.go
@@ -19,10 +19,10 @@ package keto
 import (
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/UKHomeOffice/keto/pkg/keto/util"
 	"github.com/UKHomeOffice/keto/pkg/model"
 )
 
@@ -52,7 +52,7 @@ func PrintClusters(w *tabwriter.Writer, clusters []*model.Cluster, headers bool)
 		data = append(data, clusterColumns)
 	}
 	for _, c := range clusters {
-		labels := labelsToKVs(c.Labels)
+		labels := util.LabelsToKVs(c.Labels)
 		data = append(data, []string{c.Name, labels})
 	}
 	fmt.Fprintln(w, formatData(data))
@@ -67,7 +67,7 @@ func PrintMasterPool(w *tabwriter.Writer, pools []*model.MasterPool, headers boo
 		data = append(data, nodePoolColumns)
 	}
 	for _, p := range pools {
-		labels := labelsToKVs(p.Labels)
+		labels := util.LabelsToKVs(p.Labels)
 		data = append(data, []string{p.Name, p.ClusterName, p.KubeVersion, p.CoreOSVersion, p.MachineType, labels})
 	}
 	fmt.Fprintln(w, formatData(data))
@@ -82,22 +82,11 @@ func PrintComputePool(w *tabwriter.Writer, pools []*model.ComputePool, headers b
 		data = append(data, nodePoolColumns)
 	}
 	for _, p := range pools {
-		labels := labelsToKVs(p.Labels)
+		labels := util.LabelsToKVs(p.Labels)
 		data = append(data, []string{p.Name, p.ClusterName, p.KubeVersion, p.CoreOSVersion, p.MachineType, labels})
 	}
 	fmt.Fprintln(w, formatData(data))
 	return w.Flush()
-}
-
-// labelsToKVs returns a string of labels in k=v,k=v format as a string.
-func labelsToKVs(m model.Labels) string {
-	s := []string{}
-
-	for k, v := range m {
-		s = append(s, fmt.Sprintf("%s=%s", k, v))
-	}
-	sort.Strings(s)
-	return strings.Join(s, ",")
 }
 
 // formatData formats data of slices of string slices ready for tabwriter.

--- a/pkg/keto/util/util.go
+++ b/pkg/keto/util/util.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/UKHomeOffice/keto/pkg/model"
+)
+
+// LabelsToKVs returns a string of labels in k=v,k=v format as a string.
+func LabelsToKVs(m model.Labels) string {
+	s := []string{}
+
+	for k, v := range m {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(s)
+	return strings.Join(s, ",")
+}
+
+// KVsToLabels turns a list of k=v pairs into model.Labels.
+func KVsToLabels(kvs []string) model.Labels {
+	labels := model.Labels{}
+	for _, kv := range kvs {
+		s := strings.SplitN(kv, "=", 2)
+		if len(s) == 2 {
+			labels[s[0]] = s[1]
+		}
+	}
+	return labels
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -30,6 +30,7 @@ type Cluster struct {
 	MasterPool   MasterPool
 	ComputePools []ComputePool
 	DNSZone      string
+	KubeAPIURL   string
 	Status
 }
 
@@ -47,7 +48,6 @@ type KubeArgs struct {
 
 // MasterPool is a representation of a master control plane node pool.
 type MasterPool struct {
-	KubeAPIURL string
 	NodePool
 }
 


### PR DESCRIPTION
This is a breaking change. Previously existing clusters will not be recognised properly. Also keto-k8 needs to be updated with latest cloudprovider code.