### PR TITLE
Add 'keto get config' functionality

### DIFF
--- a/bin/keto_test_e2e_setup.sh
+++ b/bin/keto_test_e2e_setup.sh
@@ -13,9 +13,6 @@ glide install
 # cfssl for cert generation
 go get -u github.com/cloudflare/cfssl/cmd/...
 
-# TODO: This can be removed when keto implements the capability to locally generate the kube config
-curl -LO https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install awscli
-
 # Get kubectl, kubeadm, kuberang
 curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
 chmod +x kubectl && mv kubectl /usr/local/bin/kubectl && kubectl help

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -54,6 +54,8 @@ type Clusters interface {
 	GetMasterPersistentIPs(clusterName string) (map[string]string, error)
 	// PushAssets pushes assets to cloud provider specific implementation.
 	PushAssets(clusterName string, a model.Assets) error
+	// GetKubeAPIURL retrieves the API URL for a given cluster
+	GetKubeAPIURL(clusterName string) (string, error)
 }
 
 // NodePooler is an abstract interface for node pools.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -181,8 +181,8 @@ func (c *Cloud) DescribeCluster(name string) error {
 	return ErrNotImplemented
 }
 
-// getKubeAPIURL returns a full Kubernetes API URL from an ELB stack.
-func (c Cloud) getKubeAPIURL(clusterName string) (string, error) {
+// GetKubeAPIURL returns a full Kubernetes API URL from an ELB stack.
+func (c Cloud) GetKubeAPIURL(clusterName string) (string, error) {
 	stack, err := c.getStack(makeELBStackName(clusterName))
 	if err != nil {
 		return "", err
@@ -202,7 +202,7 @@ func formatKubeAPIURL(host string) string {
 	return "https://" + strings.ToLower(host)
 }
 
-// getELBName returns an ELB name from the ELB stack for a given given cluster.
+// getELBName returns an ELB name from the ELB stack for a given cluster.
 func (c Cloud) getELBName(clusterName string) (string, error) {
 	res, err := c.getStackResources(makeELBStackName(clusterName))
 	if err != nil {
@@ -428,7 +428,7 @@ func (c *Cloud) CreateMasterPool(p model.MasterPool) error {
 		return err
 	}
 
-	kubeAPIURL, err := c.getKubeAPIURL(p.ClusterName)
+	kubeAPIURL, err := c.GetKubeAPIURL(p.ClusterName)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func (c *Cloud) CreateComputePool(p model.ComputePool) error {
 	if err != nil {
 		return err
 	}
-	kubeAPIURL, err := c.getKubeAPIURL(p.ClusterName)
+	kubeAPIURL, err := c.GetKubeAPIURL(p.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -441,7 +441,7 @@ func TestGetKubeAPIURL(t *testing.T) {
 			},
 		}, nil).Once()
 
-	result, err := c.getKubeAPIURL(clusterName)
+	result, err := c.GetKubeAPIURL(clusterName)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/keto/cmd/keto.go
+++ b/pkg/keto/cmd/keto.go
@@ -51,9 +51,10 @@ var (
 	}
 
 	// subcommand aliases
-	clusterCmdAliases     = []string{"cl", "clusters"}
-	masterPoolCmdAliases  = []string{"mp", "master", "masters", "masterpools"}
-	computePoolCmdAliases = []string{"cp", "compute", "computes", "computepools"}
+	clusterCmdAliases       = []string{"cl", "clusters"}
+	masterPoolCmdAliases    = []string{"mp", "master", "masters", "masterpools"}
+	computePoolCmdAliases   = []string{"cp", "compute", "computes", "computepools"}
+	clusterConfigCmdAliases = []string{"conf", "configuration"}
 )
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -258,5 +259,12 @@ func addControllerManagerExtraArgsFlag(c ...*cobra.Command) {
 func addSchedulerExtraArgsFlag(c ...*cobra.Command) {
 	for _, i := range c {
 		i.Flags().String("scheduler-extra-args", "", "Kubernetes scheduler extra arguments")
+	}
+}
+
+// addConfigOutputFileFlag adds an output file flag
+func addConfigOutputFileFlag(c ...*cobra.Command) {
+	for _, i := range c {
+		i.Flags().String("output-file", "", "Write config output to a file")
 	}
 }

--- a/pkg/keto/resource_printer.go
+++ b/pkg/keto/resource_printer.go
@@ -19,6 +19,7 @@ package keto
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -86,6 +87,28 @@ func PrintComputePool(w *tabwriter.Writer, pools []*model.ComputePool, headers b
 		data = append(data, []string{p.Name, p.ClusterName, p.KubeVersion, p.CoreOSVersion, p.MachineType, labels})
 	}
 	fmt.Fprintln(w, formatData(data))
+	return w.Flush()
+}
+
+func PrintClusterConfig(w *tabwriter.Writer, config string, outputFile string) error {
+	if len(outputFile) < 1 {
+		fmt.Fprintln(w, config)
+		return w.Flush()
+	}
+
+	_, err := os.Stat(outputFile)
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(config)
+	file.Sync()
 	return w.Flush()
 }
 


### PR DESCRIPTION
Added 'keto get config' command, which generates the kube admin config for a given cluster.

**Example use:**
```
keto get config --cloud aws --cluster testcluster01 --assets-dir /home/kash/ketoassets/ --output-file kube.cfg
```

**Optional flags:**
`--assets-dir`: Defaults to current working directory
`--output-file`: Defaults to stdout

It checks for `ca.crt` & `ca.key` (specifically required by kubeadm), and will create symlinks from your `kube_ca.crt` & `kube_ca.key` if they exist to save you the hassle.
Will check for presence of the `kubeadm` binary and error with a curl command to retrieve it (the url is built, but if the binary doesn't exist for your distro then the link won't work).