### PR TITLE
optional flag, specify compute network on cluster creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /etcd_ca.key
 /kube_ca.crt
 /kube_ca.key
+/dummycsr.json
 
 pkg/**/mocks/
 /mocks

--- a/pkg/keto/cmd/create.go
+++ b/pkg/keto/cmd/create.go
@@ -374,10 +374,19 @@ func makeComputePool(name, clusterName string, c cobra.Command) (model.ComputePo
 	if err != nil {
 		return p, err
 	}
-	networks, err := c.Flags().GetStringSlice("networks")
+
+	networks, err := c.Flags().GetStringSlice("compute-networks")
 	if err != nil {
 		return p, err
 	}
+
+	if len(networks) == 0 {
+		networks, err = c.Flags().GetStringSlice("networks")
+		if err != nil {
+			return p, err
+		}
+	}
+
 	labels, err := c.Flags().GetStringSlice("labels")
 	if err != nil {
 		return p, err
@@ -461,6 +470,10 @@ func init() {
 	)
 
 	addComputePoolsFlag(
+		createClusterCmd,
+	)
+
+	addComputeNetworksFlag(
 		createClusterCmd,
 	)
 

--- a/pkg/keto/cmd/keto.go
+++ b/pkg/keto/cmd/keto.go
@@ -225,3 +225,9 @@ func addComputePoolsFlag(c ...*cobra.Command) {
 		i.Flags().Int("compute-pools", 1, "Number of compute pools to create")
 	}
 }
+
+func addComputeNetworksFlag(c ...*cobra.Command) {
+	for _, i := range c {
+		i.Flags().StringSlice("compute-networks", []string{}, "Cloud specific list of comma separated networks for a compute pools")
+	}
+}


### PR DESCRIPTION
This allows you to specify some different subnets for the compute pools on cluster creation. If not specified it will just use the networks flag.